### PR TITLE
cmake - add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,4 +35,6 @@ qt4_wrap_ui (mpristester_SRCS
 add_executable (mpristester ${mpristester_SRCS})
 target_link_libraries (mpristester ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTDBUS_LIBRARY})
 
+INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mpristester DESTINATION bin)
+
 # vim:et:sw=3:sts=3


### PR DESCRIPTION
It was required for debian packaging to work.
It adds make install target.

Could you review and merge in if all ok?

Thanks.
Andrzej
